### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,10 +6,10 @@ Date: 2023-04-05
 Description: Estimates previously compiled state-space modeling for mouse-tracking experiments using the 'rstan' package, which provides the R interface to the Stan C++ library for Bayesian estimation.
 License: GPL (>= 3)
 Depends: methods, R (>= 3.4.0), Rcpp (>= 1.0.0)
-Imports: rstan (>= 2.18.2), rstantools (>= 1.5.1), CircStats, dtw,
+Imports: rstan (>= 2.26.0), rstantools (>= 1.5.1), CircStats, dtw,
         ggplot2, cowplot, RcppParallel
 LinkingTo: BH (>= 1.66.0-1), Rcpp (>= 1.0.0), RcppEigen (>= 0.3.3.5.0),
-        rstan (>= 2.18.2), StanHeaders (>= 2.18.0), RcppParallel
+        rstan (>= 2.26.0), StanHeaders (>= 2.26.0), RcppParallel
 Encoding: UTF-8
 LazyData: true
 NeedsCompilation: yes

--- a/inst/stan/fit_model.stan
+++ b/inst/stan/fit_model.stan
@@ -32,8 +32,8 @@ data{
   int N; // length of Y-trajectories
   int J; // number of trials (the same for each individual)
   int KK; // total number of categorical levels minus one (number of columns of the model matrix Z)
-  vector[I*J] Y[N]; // NxIJ matrix of Y-trajectories
-  vector[I*J] DY[N]; //NxIJ matrix for delta-values
+  array[N] vector[I*J] Y; // NxIJ matrix of Y-trajectories
+  array[N] vector[I*J] DY; //NxIJ matrix for delta-values
   vector<lower=0>[I] sigmaz; // sigmax parameter for the latent dynamics
   matrix<lower=0,upper=pi()>[I*J,3] bnds; // matrix of bounds (lb,ub,ub-lb) for sampling the Y-trajectories
   matrix[I*J,KK] D; // IJxKK matrix of the exp design 
@@ -50,13 +50,13 @@ parameters{
 }
 
 transformed parameters{
-  vector[I] z_pred[N]; // latent states (mean: E[X]) in the prediction stage of the Kalman filter loop
-  vector[I] z_upd[N]; // latent states (mean: E[X]) in the update stage of the Kalman filter loop
-  vector<lower=0>[I] lambda_pred[N]; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
-  vector<lower=0>[I] lambda_upd[N]; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
-  vector<lower=0>[I*J] sigma_kf[N]; // working variables for the Kalman filter loop
+  array[N] vector[I] z_pred; // latent states (mean: E[X]) in the prediction stage of the Kalman filter loop
+  array[N] vector[I] z_upd; // latent states (mean: E[X]) in the update stage of the Kalman filter loop
+  array[N] vector<lower=0>[I] lambda_pred; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
+  array[N] vector<lower=0>[I] lambda_upd; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
+  array[N] vector<lower=0>[I*J] sigma_kf; // working variables for the Kalman filter loop
   vector[I*J] kappa_vec; // working variables for the Kalman filter loop
-  vector[I*J] y_star[N]; // predicted Y-trajectories in the Kalman filter loop
+  array[N] vector[I*J] y_star; // predicted Y-trajectories in the Kalman filter loop
   vector[I*J] G; // working variables for the Kalman filter loop
   vector[I*J] z_vec; // working variables for the Kalman filter loop
   vector[I*J] lambda_pred_vec; // working variables for the Kalman filter loop

--- a/inst/stan/fit_model_gomp.stan
+++ b/inst/stan/fit_model_gomp.stan
@@ -32,8 +32,8 @@ data{
   int N; // length of Y-trajectories
   int J; // number of trials (the same for each individual)
   int KK; // total number of categorical levels minus one (number of columns of the model matrix Z)
-  vector[I*J] Y[N]; // NxIJ matrix of Y-trajectories
-  vector[I*J] DY[N]; //NxIJ matrix for delta-values
+  array[N] vector[I*J] Y; // NxIJ matrix of Y-trajectories
+  array[N] vector[I*J] DY; //NxIJ matrix for delta-values
   vector<lower=0>[I] sigmaz; // sigmax parameter for the latent dynamics
   matrix<lower=0,upper=pi()>[I*J,3] bnds; // matrix of bounds (lb,ub,ub-lb) for sampling the Y-trajectories
   matrix[I*J,KK] D; // IJxKK matrix of the exp design 
@@ -51,13 +51,13 @@ parameters{
 }
 
 transformed parameters{
-  vector[I] z_pred[N]; // latent states (mean: E[X]) in the prediction stage of the Kalman filter loop
-  vector[I] z_upd[N]; // latent states (mean: E[X]) in the update stage of the Kalman filter loop
-  vector<lower=0>[I] lambda_pred[N]; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
-  vector<lower=0>[I] lambda_upd[N]; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
-  vector<lower=0>[I*J] sigma_kf[N]; // working variables for the Kalman filter loop
+  array[N] vector[I] z_pred; // latent states (mean: E[X]) in the prediction stage of the Kalman filter loop
+  array[N] vector[I] z_upd; // latent states (mean: E[X]) in the update stage of the Kalman filter loop
+  array[N] vector<lower=0>[I] lambda_pred; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
+  array[N] vector<lower=0>[I] lambda_upd; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
+  array[N] vector<lower=0>[I*J] sigma_kf; // working variables for the Kalman filter loop
   vector[I*J] kappa_vec; // working variables for the Kalman filter loop
-  vector[I*J] y_star[N]; // predicted Y-trajectories in the Kalman filter loop
+  array[N] vector[I*J] y_star; // predicted Y-trajectories in the Kalman filter loop
   vector[I*J] G; // working variables for the Kalman filter loop
   vector[I*J] z_vec; // working variables for the Kalman filter loop
   vector[I*J] lambda_pred_vec; // working variables for the Kalman filter loop
@@ -130,10 +130,10 @@ model{
 
 generated quantities{
   // Fixed-Interval backward smoother 
-  vector[I] z_s_pred[N];
-  vector[I] z_s_upd[N]; 
-  vector[I] lambda_s_pred[N];
-  vector<lower=0>[I] lambda_s_upd[N]; 
+  array[N] vector[I] z_s_pred;
+  array[N] vector[I] z_s_upd; 
+  array[N] vector[I] lambda_s_pred;
+  array[N] vector<lower=0>[I] lambda_s_upd; 
   vector[I] G_s;
   
   z_s_upd[N] = z_upd[N];

--- a/inst/stan/fit_model_log.stan
+++ b/inst/stan/fit_model_log.stan
@@ -32,8 +32,8 @@ data{
   int N; // length of Y-trajectories
   int J; // number of trials (the same for each individual)
   int KK; // total number of categorical levels minus one (number of columns of the model matrix Z)
-  vector[I*J] Y[N]; // NxIJ matrix of Y-trajectories
-  vector[I*J] DY[N]; //NxIJ matrix for delta-values
+  array[N] vector[I*J] Y; // NxIJ matrix of Y-trajectories
+  array[N] vector[I*J] DY; //NxIJ matrix for delta-values
   vector<lower=0>[I] sigmaz; // sigmax parameter for the latent dynamics
   matrix<lower=0,upper=pi()>[I*J,3] bnds; // matrix of bounds (lb,ub,ub-lb) for sampling the Y-trajectories
   matrix[I*J,KK] D; // IJxKK matrix of the exp design 
@@ -50,13 +50,13 @@ parameters{
 }
 
 transformed parameters{
-  vector[I] z_pred[N]; // latent states (mean: E[X]) in the prediction stage of the Kalman filter loop
-  vector[I] z_upd[N]; // latent states (mean: E[X]) in the update stage of the Kalman filter loop
-  vector<lower=0>[I] lambda_pred[N]; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
-  vector<lower=0>[I] lambda_upd[N]; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
-  vector<lower=0>[I*J] sigma_kf[N]; // working variables for the Kalman filter loop
+  array[N] vector[I] z_pred; // latent states (mean: E[X]) in the prediction stage of the Kalman filter loop
+  array[N] vector[I] z_upd; // latent states (mean: E[X]) in the update stage of the Kalman filter loop
+  array[N] vector<lower=0>[I] lambda_pred; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
+  array[N] vector<lower=0>[I] lambda_upd; // latent states (variance: VAR[X]) in the prediction stage of the Kalman filter loop
+  array[N] vector<lower=0>[I*J] sigma_kf; // working variables for the Kalman filter loop
   vector[I*J] kappa_vec; // working variables for the Kalman filter loop
-  vector[I*J] y_star[N]; // predicted Y-trajectories in the Kalman filter loop
+  array[N] vector[I*J] y_star; // predicted Y-trajectories in the Kalman filter loop
   vector[I*J] G; // working variables for the Kalman filter loop
   vector[I*J] z_vec; // working variables for the Kalman filter loop
   vector[I*J] lambda_pred_vec; // working variables for the Kalman filter loop
@@ -117,10 +117,10 @@ model{
 
 generated quantities{
   // Fixed-Interval backward smoother 
-  vector[I] z_s_pred[N];
-  vector[I] z_s_upd[N]; 
-  vector[I] lambda_s_pred[N];
-  vector<lower=0>[I] lambda_s_upd[N]; 
+  array[N] vector[I] z_s_pred;
+  array[N] vector[I] z_s_upd; 
+  array[N] vector[I] lambda_s_pred;
+  array[N] vector<lower=0>[I] lambda_s_upd; 
   vector[I] G_s;
   
   z_s_upd[N] = z_upd[N];

--- a/inst/stan/simulate_data.stan
+++ b/inst/stan/simulate_data.stan
@@ -28,8 +28,8 @@ vector kronecker_simplified_J(int I, int J, vector x){
   vector compute_deltay(vector x, int I, real pT, real pD, real pC){
     vector[I] dx;
     for(i in 1:I){
-      if(x[i]>pC) dx[i] = fabs(x[i]-pD);
-      else dx[i] = fabs(x[i]-pT);}
+      if(x[i]>pC) dx[i] = abs(x[i]-pD);
+      else dx[i] = abs(x[i]-pT);}
     return dx;
   }
 }
@@ -39,7 +39,7 @@ data{
   int N; // length of Y-trajectories
   int J; // number of trials (the same for each individual)
   int KK; // total number of categorical levels minus one (number of columns of the model matrix Z)
-  vector[I*J] Y[N]; // NxIJ matrix of Y-trajectories
+  array[N] vector[I*J] Y; // NxIJ matrix of Y-trajectories
   vector<lower=0>[I] sigmaz; // sigmax parameter for the latent dynamics
   matrix<lower=0,upper=pi()>[I*J,3] bnds; // matrix of bounds (lb,ub,ub-lb) for sampling the Y-trajectories
   matrix[I*J,KK] D; // IJxKK matrix for delta-values
@@ -78,12 +78,12 @@ model{
 }
 
 generated quantities{
-  vector[I] z[N]; // NxI matrix of latent dynamics
-  vector[I*J] mu[N]; // NxIJ matrix of von-mises means
-  vector[I*J] y_sim[N]; // NxIJ matrix of simulated Y-trajectories
-  vector[I*J] dy_sim[N]; // NxIJ matrix of delta values
+  array[N] vector[I] z; // NxI matrix of latent dynamics
+  array[N] vector[I*J] mu; // NxIJ matrix of von-mises means
+  array[N] vector[I*J] y_sim; // NxIJ matrix of simulated Y-trajectories
+  array[N] vector[I*J] dy_sim; // NxIJ matrix of delta values
   vector[I*J] z_vec; // working variable
-  vector[I*J] kappas[N]; // NxIJ matrix of kappa parameters
+  array[N] vector[I*J] kappas; // NxIJ matrix of kappa parameters
 
   // Sampling the latent dynamics
   z[1] = rep_vector(1e-04,I);

--- a/inst/stan/simulate_data_gomp.stan
+++ b/inst/stan/simulate_data_gomp.stan
@@ -28,8 +28,8 @@ vector kronecker_simplified_J(int I, int J, vector x){
   vector compute_deltay(vector x, int I, real pT, real pD, real pC){
     vector[I] dx;
     for(i in 1:I){
-      if(x[i]>=pC) dx[i] = fabs(x[i]-pD);
-      else if(x[i]<pC) dx[i] = fabs(x[i]-pT);}
+      if(x[i]>=pC) dx[i] = abs(x[i]-pD);
+      else if(x[i]<pC) dx[i] = abs(x[i]-pT);}
     return dx;
   }
 }
@@ -39,7 +39,7 @@ data{
   int N; // length of Y-trajectories
   int J; // number of trials (the same for each individual)
   int KK; // total number of categorical levels minus one (number of columns of the model matrix Z)
-  vector[I*J] Y[N]; // NxIJ matrix of Y-trajectories
+  array[N] vector[I*J] Y; // NxIJ matrix of Y-trajectories
   vector<lower=0>[I] sigmaz; // sigmax parameter for the latent dynamics
   matrix<lower=0,upper=pi()>[I*J,3] bnds; // matrix of bounds (lb,ub,ub-lb) for sampling the Y-trajectories
   matrix[I*J,KK] D; // IJxKK matrix for delta-values
@@ -90,12 +90,12 @@ model{
 }
 
 generated quantities{
-  vector[I] z[N]; // NxI matrix of latent dynamics
-  vector[I*J] mu[N]; // NxIJ matrix of von-mises means
-  vector[I*J] y_sim[N]; // NxIJ matrix of simulated Y-trajectories
-  vector[I*J] dy_sim[N]; // NxIJ matrix of delta values
+  array[N] vector[I] z; // NxI matrix of latent dynamics
+  array[N] vector[I*J] mu; // NxIJ matrix of von-mises means
+  array[N] vector[I*J] y_sim; // NxIJ matrix of simulated Y-trajectories
+  array[N] vector[I*J] dy_sim; // NxIJ matrix of delta values
   vector[I*J] z_vec; // working variable
-  vector<lower=kappa_lb,upper=kappa_ub>[I*J] kappas[N]; // working variable
+  array[N] vector<lower=kappa_lb,upper=kappa_ub>[I*J] kappas; // working variable
 
   // Sampling the latent dynamics
   z[1] = rep_vector(1e-04,I);

--- a/inst/stan/simulate_data_log.stan
+++ b/inst/stan/simulate_data_log.stan
@@ -28,8 +28,8 @@ vector kronecker_simplified_J(int I, int J, vector x){
   vector compute_deltay(vector x, int I, real pT, real pD, real pC){
     vector[I] dx;
     for(i in 1:I){
-      if(x[i]>=pC) dx[i] = fabs(x[i]-pD);
-      else dx[i] = fabs(x[i]-pT);}
+      if(x[i]>=pC) dx[i] = abs(x[i]-pD);
+      else dx[i] = abs(x[i]-pT);}
     return dx;
   }
 }
@@ -39,7 +39,7 @@ data{
   int N; // length of Y-trajectories
   int J; // number of trials (the same for each individual)
   int KK; // total number of categorical levels minus one (number of columns of the model matrix Z)
-  vector[I*J] Y[N]; // NxIJ matrix of Y-trajectories
+  array[N] vector[I*J] Y; // NxIJ matrix of Y-trajectories
   vector<lower=0>[I] sigmaz; // sigmax parameter for the latent dynamics
   matrix<lower=0,upper=pi()>[I*J,3] bnds; // matrix of bounds (lb,ub,ub-lb) for sampling the Y-trajectories
   matrix[I*J,KK] D; // IJxKK matrix for delta-values
@@ -78,12 +78,12 @@ model{
 }
 
 generated quantities{
-  vector[I] z[N]; // NxI matrix of latent dynamics
-  vector[I*J] mu[N]; // NxIJ matrix of von-mises means
-  vector[I*J] y_sim[N]; // NxIJ matrix of simulated Y-trajectories
-  vector[I*J] dy_sim[N]; // NxIJ matrix of delta values
+  array[N] vector[I] z; // NxI matrix of latent dynamics
+  array[N] vector[I*J] mu; // NxIJ matrix of von-mises means
+  array[N] vector[I*J] y_sim; // NxIJ matrix of simulated Y-trajectories
+  array[N] vector[I*J] dy_sim; // NxIJ matrix of delta values
   vector[I*J] z_vec; // working variable
-  vector<lower=kappa_lb,upper=kappa_ub>[I*J] kappas[N]; // working variable
+  array[N] vector<lower=kappa_lb,upper=kappa_ub>[I*J] kappas; // working variable
 
   // Sampling the latent dynamics
   z[1] = rep_vector(1e-04,I);


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `fabs` replaced by `abs`

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
